### PR TITLE
feat: support poetry 2.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,18 @@
-[tool.poetry]
+[project]
 name = "cobo-cli"
 version = "0.0.5"
 description = "Cobo Command-line Tool"
-authors = ["Cobo <support@cobo.com>"]
+authors = [
+    { "name" = "Cobo", "email" = "<support@cobo.com>" },
+]
 license = "MIT"
 readme = "README.md"
 packages = [{ include = "cobo_cli" }]
+
+[project.urls]
+Homepage = "https://github.com/CoboGlobal/cobo-cli"
+Repository = "https://github.com/CoboGlobal/cobo-cli.git"
+Documentation = "https://www.cobo.com/developers/v2/guides/overview/introduction"
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
seeing some build failure when building against poetry 2.0

```
    File "/private/tmp/pip-build-env-n7j21in1/overlay/lib/python3.13/site-packages/poetry/core/masonry/metadata.py", line 114, in from_package
      if name == "documentation" and url == package.urls["Documentation"]:
                                            ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  KeyError: 'Documentation'
  error: subprocess-exited-with-error
```